### PR TITLE
Add duration (by default) to tblock command

### DIFF
--- a/forward/converters.py
+++ b/forward/converters.py
@@ -27,37 +27,30 @@ TIME_RE_STRING = r"|".join(
 TIME_RE = re.compile(TIME_RE_STRING, re.I)
 TIME_SPLIT = re.compile(r"t(?:ime)?=")
 
-_ = i18n.Translator("Mutes", __file__)
+_ = i18n.Translator("Forward", __file__)
 
+def str_to_timedelta(
+    duration: str
+) -> Dict[str, Union[timedelta, str, None]]:
+    time_split = TIME_SPLIT.split(argument)
+    result: Dict[str, Union[timedelta, str, None]] = {}
+    if time_split:
+        maybe_time = time_split[-1]
+    else:
+        maybe_time = argument
 
-class MuteTime(Converter):
-    """
-    This will parse my defined multi response pattern and provide usable formats
-    to be used in multiple reponses
-    """
-
-    async def convert(
-        self, duration: str
-    ) -> Dict[str, Union[timedelta, str, None]]:
-        time_split = TIME_SPLIT.split(argument)
-        result: Dict[str, Union[timedelta, str, None]] = {}
-        if time_split:
-            maybe_time = time_split[-1]
-        else:
-            maybe_time = argument
-
-        time_data = {}
-        for time in TIME_RE.finditer(maybe_time):
-            argument = argument.replace(time[0], "")
-            for k, v in time.groupdict().items():
-                if v:
-                    time_data[k] = int(v)
-        if time_data:
-            try:
-                result["duration"] = timedelta(**time_data)
-            except OverflowError:
-                raise commands.BadArgument(
-                    _("The time provided is too long; use a more reasonable time.")
-                )
-        result["reason"] = argument.strip()
-        return result
+    time_data = {}
+    for time in TIME_RE.finditer(maybe_time):
+        argument = argument.replace(time[0], "")
+        for k, v in time.groupdict().items():
+            if v:
+                time_data[k] = int(v)
+    if time_data:
+        try:
+            result["duration"] = timedelta(**time_data)
+        except OverflowError:
+            raise commands.BadArgument(
+                _("The time provided is too long; use a more reasonable time.")
+            )
+    result["reason"] = argument.strip()
+    return result

--- a/forward/converters.py
+++ b/forward/converters.py
@@ -7,7 +7,7 @@ from discord.ext.commands.converter import Converter
 from redbot.core import commands
 from redbot.core import i18n
 
-log = logging.getLogger("red.cogs.mutes")
+log = logging.getLogger("red.cogs.forward")
 
 # the following regex is slightly modified from Red
 # it's changed to be slightly more strict on matching with finditer

--- a/forward/converters.py
+++ b/forward/converters.py
@@ -32,16 +32,16 @@ _ = i18n.Translator("Forward", __file__)
 def str_to_timedelta(
     duration: str
 ) -> Dict[str, Union[timedelta, str, None]]:
-    time_split = TIME_SPLIT.split(argument)
+    time_split = TIME_SPLIT.split(duration)
     result: Dict[str, Union[timedelta, str, None]] = {}
     if time_split:
         maybe_time = time_split[-1]
     else:
-        maybe_time = argument
+        maybe_time = duration
 
     time_data = {}
     for time in TIME_RE.finditer(maybe_time):
-        argument = argument.replace(time[0], "")
+        duration = duration.replace(time[0], "")
         for k, v in time.groupdict().items():
             if v:
                 time_data[k] = int(v)
@@ -52,5 +52,5 @@ def str_to_timedelta(
             raise commands.BadArgument(
                 _("The time provided is too long; use a more reasonable time.")
             )
-    result["reason"] = argument.strip()
+    result["reason"] = duration.strip()
     return result

--- a/forward/converters.py
+++ b/forward/converters.py
@@ -37,7 +37,7 @@ class MuteTime(Converter):
     """
 
     async def convert(
-        self, ctx: commands.Context, argument: str
+        self, duration: str
     ) -> Dict[str, Union[timedelta, str, None]]:
         time_split = TIME_SPLIT.split(argument)
         result: Dict[str, Union[timedelta, str, None]] = {}

--- a/forward/converters.py
+++ b/forward/converters.py
@@ -1,0 +1,63 @@
+import logging
+import re
+from typing import Union, Dict
+from datetime import timedelta
+
+from discord.ext.commands.converter import Converter
+from redbot.core import commands
+from redbot.core import i18n
+
+log = logging.getLogger("red.cogs.mutes")
+
+# the following regex is slightly modified from Red
+# it's changed to be slightly more strict on matching with finditer
+# this is to prevent "empty" matches when parsing the full reason
+# This is also designed more to allow time interval at the beginning or the end of the mute
+# to account for those times when you think of adding time *after* already typing out the reason
+# https://github.com/Cog-Creators/Red-DiscordBot/blob/V3/develop/redbot/core/commands/converter.py#L55
+TIME_RE_STRING = r"|".join(
+    [
+        r"((?P<weeks>\d+?)\s?(weeks?|w))",
+        r"((?P<days>\d+?)\s?(days?|d))",
+        r"((?P<hours>\d+?)\s?(hours?|hrs|hr?))",
+        r"((?P<minutes>\d+?)\s?(minutes?|mins?|m(?!o)))",  # prevent matching "months"
+        r"((?P<seconds>\d+?)\s?(seconds?|secs?|s))",
+    ]
+)
+TIME_RE = re.compile(TIME_RE_STRING, re.I)
+TIME_SPLIT = re.compile(r"t(?:ime)?=")
+
+_ = i18n.Translator("Mutes", __file__)
+
+
+class MuteTime(Converter):
+    """
+    This will parse my defined multi response pattern and provide usable formats
+    to be used in multiple reponses
+    """
+
+    async def convert(
+        self, ctx: commands.Context, argument: str
+    ) -> Dict[str, Union[timedelta, str, None]]:
+        time_split = TIME_SPLIT.split(argument)
+        result: Dict[str, Union[timedelta, str, None]] = {}
+        if time_split:
+            maybe_time = time_split[-1]
+        else:
+            maybe_time = argument
+
+        time_data = {}
+        for time in TIME_RE.finditer(maybe_time):
+            argument = argument.replace(time[0], "")
+            for k, v in time.groupdict().items():
+                if v:
+                    time_data[k] = int(v)
+        if time_data:
+            try:
+                result["duration"] = timedelta(**time_data)
+            except OverflowError:
+                raise commands.BadArgument(
+                    _("The time provided is too long; use a more reasonable time.")
+                )
+        result["reason"] = argument.strip()
+        return result

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -2,7 +2,7 @@ from redbot.core import commands, checks, Config
 # from googletrans import Translator
 import discord
 import uuid
-from .converters import MuteTime
+from .converters import str_to_timedelta
 from datetime import datetime, timezone
 import asyncio
 import logging
@@ -270,13 +270,13 @@ class Forward(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.guildowner()
-    async def tblock(self, ctx, user: discord.Member, time: Optional[MuteTime] = None):
+    async def tblock(self, ctx, user: discord.Member, time: Optional[str] = "5d"):
         """Blocks a member from sending dms to the bot
         """
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
-                duration = time.get("duration") if time else MuteTime().convert(duration="5d").get("duration")
+                duration = str_to_timedelta(duration=time).get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -276,7 +276,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
-                duration = time.get("duration") if time else MuteTime().convert("5d").get("duration")
+                duration = time.get("duration") if time else MuteTime().convert(duration="5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -276,7 +276,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
-                duration = time.get("duration") if time else MuteTime().convert("5d").get("duration")
+                duration = time.get("duration") if time else MuteTime().convert(argument="5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -252,10 +252,10 @@ class Forward(commands.Cog):
             userid = str(user.id)
             if userid not in blocked:
                 duration = time.get("duration") if time else MuteTime("5d").get("duration")
-                blocked[userid] = datetime.now(timezone.utc) + duration # until
-                await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=humanize_timedelta(timedelta=blocked[userid])))
+                blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
+                await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=humanize_timedelta(timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
             else:
-                await ctx.maybe_send_embed("This user is already blocked until {}.".format(humanize_timedelta(timedelta=blocked[userid])))
+                await ctx.maybe_send_embed("This user is already blocked until {}.".format(humanize_timedelta(timedelta=timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
 
     @commands.command()
     @commands.guild_only()
@@ -280,7 +280,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid in blocked:
-                await ctx.maybe_send_embed("User <@{id}> is blocked until.".format(id=userid, until=humanize_timedelta(timedelta=blocked[userid])))
+                await ctx.maybe_send_embed("User <@{id}> is blocked until.".format(id=userid, until=humanize_timedelta(timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
             else:
                 await ctx.maybe_send_embed("This user is not blocked.")
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -276,7 +276,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
-                duration = time.get("duration") if time else MuteTime().convert(ctx, "5d").get("duration")
+                duration = time.get("duration") if time else MuteTime().convert("5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -3,7 +3,6 @@ from redbot.core import commands, checks, Config
 import discord
 import uuid
 from .converters import MuteTime
-from redbot.core.utils.chat_formatting import humanize_timedelta
 from datetime import datetime, timedelta, timezone
 
 from typing import Optional
@@ -253,9 +252,9 @@ class Forward(commands.Cog):
             if userid not in blocked:
                 duration = time.get("duration") if time else MuteTime("5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
-                await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=humanize_timedelta(timedelta=datetime.fromtimestamp(blocked[userid]))))
+                await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:
-                await ctx.maybe_send_embed("This user is already blocked until {}.".format(humanize_timedelta(timedelta=datetime.fromtimestamp(blocked[userid]))))
+                await ctx.maybe_send_embed("This user is already blocked until {}.".format(until=datetime.fromtimestamp(blocked[userid])))
 
     @commands.command()
     @commands.guild_only()
@@ -280,7 +279,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid in blocked:
-                await ctx.maybe_send_embed("User <@{id}> is blocked until.".format(id=userid, until=humanize_timedelta(timedelta=datetime.fromtimestamp(blocked[userid]))))
+                await ctx.maybe_send_embed("User <@{id}> is blocked until.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:
                 await ctx.maybe_send_embed("This user is not blocked.")
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -46,15 +46,16 @@ class Forward(commands.Cog):
         await self.bot.wait_until_red_ready()
         while True:
             try:
-                async with self.config.blocked() as blocked:
-                    for userid, until in blocked:
-                        now = datetime.now(timezone.utc).timestamp()
-                        log.debug("Checking if {} should be unblocked. Now: {}, Until: {}".format(userid, now, until))
-                        if now > until:
-                            del blocked[userid]
+                await self._process_expired_blocks()
             except Exception:
                 log.error("Error checking bot unblocks", exc_info=True)
             await asyncio.sleep(60) # 60 seconds
+
+    async def _process_expired_blocks(self):
+        async with self.config.blocked() as blocked:
+            for userid, until in blocked.items():
+                if datetime.now(timezone.utc).timestamp() > until:
+                    del blocked[userid]
 
     async def _destination(self, msg: str = None, embed: discord.Embed = None):
         await self.bot.wait_until_ready()

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -3,7 +3,7 @@ from redbot.core import commands, checks, Config
 import discord
 import uuid
 from .converters import str_to_timedelta
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 import asyncio
 import logging
 
@@ -278,6 +278,7 @@ class Forward(commands.Cog):
             userid = str(user.id)
             if userid not in blocked:
                 duration = str_to_timedelta(duration=time).get("duration")
+                duration = duration if type(duration) is timedelta else str_to_timedelta(duration="5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from sending messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -255,7 +255,7 @@ class Forward(commands.Cog):
     @commands.guild_only()
     @checks.guildowner()
     async def tunblock(self, ctx, user: discord.Member):
-        """Blocks a member from sending dm
+        """Unblocks a member from sending dm
         """
         async with self.config.blocked() as blocked:
             userid = str(user.id)

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -270,13 +270,13 @@ class Forward(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.guildowner()
-    async def tblock(self, ctx, user: discord.Member, time: Optional[MuteTime] = None):
+    async def tblock(self, ctx, user: discord.Member, time: Optional[MuteTime] = "5d"):
         """Blocks a member from sending dms to the bot
         """
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
-                duration = time.get("duration") if time else MuteTime().convert(argument="5d").get("duration")
+                duration = time.get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -253,9 +253,9 @@ class Forward(commands.Cog):
             if userid not in blocked:
                 duration = time.get("duration") if time else MuteTime("5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
-                await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=humanize_timedelta(timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
+                await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=humanize_timedelta(timedelta=datetime.fromtimestamp(blocked[userid]))))
             else:
-                await ctx.maybe_send_embed("This user is already blocked until {}.".format(humanize_timedelta(timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
+                await ctx.maybe_send_embed("This user is already blocked until {}.".format(humanize_timedelta(timedelta=datetime.fromtimestamp(blocked[userid]))))
 
     @commands.command()
     @commands.guild_only()
@@ -280,7 +280,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid in blocked:
-                await ctx.maybe_send_embed("User <@{id}> is blocked until.".format(id=userid, until=humanize_timedelta(timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
+                await ctx.maybe_send_embed("User <@{id}> is blocked until.".format(id=userid, until=humanize_timedelta(timedelta=datetime.fromtimestamp(blocked[userid]))))
             else:
                 await ctx.maybe_send_embed("This user is not blocked.")
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -53,7 +53,8 @@ class Forward(commands.Cog):
 
     async def _process_expired_blocks(self):
         async with self.config.blocked() as blocked:
-            for userid, until in blocked.items():
+            for userid in list(blocked.keys()):
+                until = blocked[userid]
                 if datetime.now(timezone.utc).timestamp() > until:
                     del blocked[userid]
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -280,9 +280,9 @@ class Forward(commands.Cog):
                 duration = str_to_timedelta(duration=time).get("duration")
                 duration = duration if type(duration) is timedelta else str_to_timedelta(duration="5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
-                await ctx.maybe_send_embed("Blocked <@{id}> from sending messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
+                await ctx.maybe_send_embed("Blocked <@{id}> from sending messages to the bot until <t:{until}>.".format(id=userid, until=int(blocked[userid])))
             else:
-                await ctx.maybe_send_embed("This user is already blocked until {}.".format(datetime.fromtimestamp(blocked[userid])))
+                await ctx.maybe_send_embed("This user is already blocked until <t:{}>.".format(int(blocked[userid])))
 
     @commands.command()
     @commands.guild_only()
@@ -307,7 +307,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid in blocked:
-                await ctx.maybe_send_embed("User <@{id}> is blocked until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
+                await ctx.maybe_send_embed("User <@{id}> is blocked until <t:{until}>.".format(id=userid, until=int(blocked[userid])))
             else:
                 await ctx.maybe_send_embed("This user is not blocked.")
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -250,7 +250,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
-                duration = time.get("duration") if time else MuteTime("5d").get("duration")
+                duration = time.get("duration") if time else MuteTime().convert("5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -14,7 +14,7 @@ from typing import Optional, Dict
 log = logging.getLogger("red.cogs.forward")
 
 class Forward(commands.Cog):
-    """Forward messages sent to the bot to the bot owner or in a specified channel."""
+    """Forward messages sent to the bot to the bot owner or a specified channel."""
 
     __version__ = "1.2.5"
 
@@ -272,14 +272,14 @@ class Forward(commands.Cog):
     @commands.guild_only()
     @checks.guildowner()
     async def tblock(self, ctx, user: discord.Member, time: Optional[str] = "5d"):
-        """Blocks a member from sending dms to the bot
+        """Blocks a member from sending DMs to the bot
         """
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
                 duration = str_to_timedelta(duration=time).get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
-                await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
+                await ctx.maybe_send_embed("Blocked <@{id}> from sending messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:
                 await ctx.maybe_send_embed("This user is already blocked until {}.".format(datetime.fromtimestamp(blocked[userid])))
 
@@ -293,7 +293,7 @@ class Forward(commands.Cog):
             userid = str(user.id)
             if userid in blocked:
                 del blocked[userid]
-                await ctx.maybe_send_embed("Unblocked <@{}> from sending messages to the bot.".format(userid))
+                await ctx.maybe_send_embed("Unblocked <@{}> sending messages to the bot.".format(userid))
             else:
                 await ctx.maybe_send_embed("This user is not blocked.")
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -46,16 +46,15 @@ class Forward(commands.Cog):
         await self.bot.wait_until_red_ready()
         while True:
             try:
-                await self._process_expired_blocks()
+                async with self.config.blocked() as blocked:
+                    for userid, until in blocked:
+                        now = datetime.now(timezone.utc).timestamp()
+                        log.debug("Checking if {} should be unblocked. Now: {}, Until: {}".format(userid, now, until))
+                        if now > until:
+                            del blocked[userid]
             except Exception:
                 log.error("Error checking bot unblocks", exc_info=True)
             await asyncio.sleep(60) # 60 seconds
-
-    async def _process_expired_blocks(self):
-        async with self.config.blocked() as blocked:
-            for userid, until in enumerate(blocked):
-                if datetime.now(timezone.utc).timestamp() > until:
-                    del blocked[userid]
 
     async def _destination(self, msg: str = None, embed: discord.Embed = None):
         await self.bot.wait_until_ready()

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -254,7 +254,7 @@ class Forward(commands.Cog):
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:
-                await ctx.maybe_send_embed("This user is already blocked until {}.".format(until=datetime.fromtimestamp(blocked[userid])))
+                await ctx.maybe_send_embed("This user is already blocked until {}.".format(datetime.fromtimestamp(blocked[userid])))
 
     @commands.command()
     @commands.guild_only()
@@ -279,7 +279,7 @@ class Forward(commands.Cog):
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid in blocked:
-                await ctx.maybe_send_embed("User <@{id}> is blocked until.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
+                await ctx.maybe_send_embed("User <@{id}> is blocked until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:
                 await ctx.maybe_send_embed("This user is not blocked.")
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -53,7 +53,7 @@ class Forward(commands.Cog):
 
     async def _process_expired_blocks(self):
         async with self.config.blocked() as blocked:
-            for userid, until in blocked:
+            for userid, until in enumerate(blocked):
                 if datetime.now(timezone.utc).timestamp() > until:
                     del blocked[userid]
 

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -270,13 +270,13 @@ class Forward(commands.Cog):
     @commands.command()
     @commands.guild_only()
     @checks.guildowner()
-    async def tblock(self, ctx, user: discord.Member, time: Optional[MuteTime] = "5d"):
+    async def tblock(self, ctx, user: discord.Member, time: Optional[MuteTime] = None):
         """Blocks a member from sending dms to the bot
         """
         async with self.config.blocked() as blocked:
             userid = str(user.id)
             if userid not in blocked:
-                duration = time.get("duration")
+                duration = time.get("duration") if time else MuteTime().convert(ctx, "5d").get("duration")
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=datetime.fromtimestamp(blocked[userid])))
             else:

--- a/forward/forward.py
+++ b/forward/forward.py
@@ -255,7 +255,7 @@ class Forward(commands.Cog):
                 blocked[userid] = (datetime.now(timezone.utc) + duration).timestamp() # until
                 await ctx.maybe_send_embed("Blocked <@{id}> from send messages to the bot until {until}.".format(id=userid, until=humanize_timedelta(timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
             else:
-                await ctx.maybe_send_embed("This user is already blocked until {}.".format(humanize_timedelta(timedelta=timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
+                await ctx.maybe_send_embed("This user is already blocked until {}.".format(humanize_timedelta(timedelta=datetime.datetime.fromtimestamp(blocked[userid]))))
 
     @commands.command()
     @commands.guild_only()


### PR DESCRIPTION
Updates the `.tblock` command, adding an extra argument for block duration. The argument is optional and defaults to "5d" (5 days).

Usage: `.tblock <userid> <duration>`

Duration is a string e.g `1 day`, `1d`, `2 months`, `60s`

Adds a command to check if user is blocked, `.tcheckblock <userid>`