### PR TITLE
Fix userinfo command

### DIFF
--- a/mod/names.py
+++ b/mod/names.py
@@ -189,7 +189,7 @@ class ModInfo(MixinMeta):
         roles = member.roles[-1:0:-1]
         names, nicks = await self.get_names_and_nicks(member)
 
-        joined_at = joined_at.replace(tzinfo=datetime.timezone.utc)
+        joined_at = member.joined_at.replace(tzinfo=datetime.timezone.utc)
         user_created = int(member.created_at.replace(tzinfo=datetime.timezone.utc).timestamp())
         voice_state = member.voice
         member_number = (

--- a/mod/names.py
+++ b/mod/names.py
@@ -189,8 +189,8 @@ class ModInfo(MixinMeta):
         roles = member.roles[-1:0:-1]
         names, nicks = await self.get_names_and_nicks(member)
 
-        joined_at = member.joined_at.replace(tzinfo=datetime.timezone.utc)
-        user_created = int(member.created_at.replace(tzinfo=datetime.timezone.utc).timestamp())
+        joined_at = member.joined_at
+        user_created = int(member.created_at.timestamp())
         voice_state = member.voice
         member_number = (
             sorted(guild.members, key=lambda m: m.joined_at or ctx.message.created_at).index(


### PR DESCRIPTION
- Fixes the error `local variable 'joined_at' referenced before assignment` when using the `userinfo` command.
- Removes unnecessary timezone conversion.