### PR TITLE
Add "textall" command

### DIFF
--- a/spam/spam.py
+++ b/spam/spam.py
@@ -130,8 +130,9 @@ class spam(commands.Cog):
             msg += "**{}** ({}) \n".format(key, strings[key])
         if not msg:
             await ctx.maybe_send_embed("List is empty.")
-        msg = "**Blocked Text:**\n"+msg
-        await menu(ctx, list(pagify(text=msg, page_length=999999999)), DEFAULT_CONTROLS)
+        with open("/data/cogs/CogManager/cogs/spam/blocked_text.txt", "w") as text_file:
+            text_file.write("%s" % msg)
+        await ctx.maybe_send_embed("List saved to file.")
 
     @_list.command()
     async def server(self, ctx):

--- a/spam/spam.py
+++ b/spam/spam.py
@@ -122,6 +122,18 @@ class spam(commands.Cog):
         await menu(ctx, list(pagify(msg)), DEFAULT_CONTROLS)
 
     @_list.command()
+    async def textall(self, ctx):
+        """ Shows a list of blocked texts"""
+        strings = await self.config.guild(ctx.guild).strings()
+        msg = ""
+        for key in strings:
+            msg += "**{}** ({}) \n".format(key, strings[key])
+        if not msg:
+            await ctx.maybe_send_embed("List is empty.")
+        msg = "**Blocked Text:**\n"+msg
+        await menu(ctx, list(pagify(text=msg, page_length=999999999)), DEFAULT_CONTROLS)
+
+    @_list.command()
     async def server(self, ctx):
         """ Shows a list of blocked servers """
         invites = await self.config.guild(ctx.guild).invites()


### PR DESCRIPTION
Saves the entire spam text list to a file on the server, as this can't be output directly to a channel due to API limits.