### PR TITLE
extendedmodlog & spam: make URLs unclickable

### DIFF
--- a/extendedmodlog/eventmixin.py
+++ b/extendedmodlog/eventmixin.py
@@ -1,7 +1,8 @@
 import asyncio
 import datetime
 import logging
-from typing import Sequence, Union, cast, Optional, Tuple
+from typing import Sequence, Union, cast, Optional, Tuple, Pattern
+import re
 
 import discord
 from discord.ext.commands.converter import Converter
@@ -20,6 +21,9 @@ from redbot.core.utils.chat_formatting import (
 _ = Translator("ExtendedModLog", __file__)
 logger = logging.getLogger("red.trusty-cogs.ExtendedModLog")
 
+LINK_RE: Pattern = re.compile(
+    r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)", re.I
+)
 
 class CommandPrivs(Converter):
     """
@@ -380,8 +384,9 @@ class EventMixin:
                 channel=message_channel,
             )
         if embed_links:
+            filtered_content = LINK_RE.sub(r"\g<0>​", message.content) # make urls unclickable
             embed = discord.Embed(
-                description=f"{message.author.mention}: {message.content}",
+                description=f"{message.author.mention}: {filtered_content}",
                 colour=await self.get_event_colour(guild, "message_delete"),
                 timestamp=time,
             )

--- a/spam/spam.py
+++ b/spam/spam.py
@@ -12,6 +12,10 @@ INVITE_RE: Pattern = re.compile(
     r"(?:https?\:\/\/)?discord(?:\.gg|(?:app)?\.com\/invite)\/([a-zA-Z0-9]+)", re.I
 )
 
+LINK_RE: Pattern = re.compile(
+    r"https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)", re.I
+)
+
 
 class spam(commands.Cog):
     """ MTA:SA Spam Cog """
@@ -189,7 +193,7 @@ class spam(commands.Cog):
                 if feed:
                     embed = discord.Embed(colour=discord.Colour(0xf5a623), description="Spam protection deleted an invite (Whitelist) in <#"+str(ctx.channel.id)+">")
                     embed.add_field(name="**Author:**", value="<@"+str(ctx.author.id)+">", inline=False)
-                    embed.add_field(name="**Message:**", value=ctx.content, inline=False)
+                    embed.add_field(name="**Message:**", value=LINK_RE.sub(r"\g<0>​", ctx.content), inline=False) # make urls unclickable
                     await self.bot.get_channel(int(await self.config.guild(ctx.guild).feed())).send(embed=embed)
                 return
 
@@ -201,7 +205,7 @@ class spam(commands.Cog):
                     if feed:
                         embed = discord.Embed(colour=discord.Colour(0xf5a623), description="Spam protection deleted an invite (Blocked) in <#"+str(ctx.channel.id)+">")
                         embed.add_field(name="**Author:**", value="<@"+str(ctx.author.id)+">", inline=False)
-                        embed.add_field(name="**Message:**", value=ctx.content, inline=False)
+                        embed.add_field(name="**Message:**", value=LINK_RE.sub(r"\g<0>​", ctx.content), inline=False) # make urls unclickable
                         await self.bot.get_channel(int(await self.config.guild(ctx.guild).feed())).send(embed=embed)
                     return await ctx.delete()
 
@@ -212,7 +216,7 @@ class spam(commands.Cog):
                 if feed:
                     embed = discord.Embed(colour=discord.Colour(0xf5a623), description="Spam protection deleted a message in <#"+str(ctx.channel.id)+">")
                     embed.add_field(name="**Author:**", value="<@"+str(ctx.author.id)+">", inline=False)
-                    embed.add_field(name="**Message:**", value=ctx.content, inline=False)
+                    embed.add_field(name="**Message:**", value=LINK_RE.sub(r"\g<0>​", ctx.content), inline=False) # make urls unclickable
                     await self.bot.get_channel(int(await self.config.guild(ctx.guild).feed())).send(embed=embed)
                 await ctx.delete()
                 return


### PR DESCRIPTION
This PR makes modlog and spam message links unclickable to prevent misclicks. It does this by inserting an invisible codepoint after the URL